### PR TITLE
cryptodisk: Implement NV index

### DIFF
--- a/grub-core/tpm2/module.c
+++ b/grub-core/tpm2/module.c
@@ -757,12 +757,27 @@ static grub_err_t
 grub_tpm2_protector_nv_recover (const struct grub_tpm2_protector_context *ctx,
 				grub_uint8_t **key, grub_size_t *key_size)
 {
-  (void)ctx;
-  (void)key;
-  (void)key_size;
+  TPM_HANDLE sealed_handle = ctx->nv;
+  tpm2key_policy_t policy_seq = NULL;
+  grub_err_t err;
 
-  return grub_error (GRUB_ERR_NOT_IMPLEMENTED_YET,
-		     N_("NV Index mode is not implemented yet"));
+  /* Create a basic policy sequence based on the given PCR selection */
+  err = grub_tpm2_protector_simple_policy_seq (ctx, &policy_seq);
+  if (err != GRUB_ERR_NONE)
+    goto exit;
+
+  err = grub_tpm2_protector_unseal (policy_seq, sealed_handle, key, key_size);
+
+  /* Pop error messages on success */
+  if (err == GRUB_ERR_NONE)
+    while (grub_error_pop ());
+
+exit:
+  TPM2_FlushContext (sealed_handle);
+
+  grub_tpm2key_free_policy_seq (policy_seq);
+
+  return err;
 }
 
 static grub_err_t


### PR DESCRIPTION
Currently with the TPM2 protector, only SRK mode is supported and NV index support is just a stub. Implement the NV index option.

Note: This only extends support on the unseal path. grub2_protect has not been updated. tpm2-tools can be used to insert a key into the NV index.