### PR TITLE
cryptodisk: Fallback to passphrase

### DIFF
--- a/grub-core/disk/cryptodisk.c
+++ b/grub-core/disk/cryptodisk.c
@@ -1191,11 +1191,16 @@ grub_cryptodisk_scan_device_real (const char *name,
 		  source->name, source->partition != NULL ? "," : "",
 		  part != NULL ? part : N_("UNKNOWN"), dev->uuid);
       grub_free (part);
-      goto error;
     }
 
   if (!cargs->key_len)
     {
+      if (grub_errno)
+	{
+	  grub_print_error ();
+	  grub_errno = GRUB_ERR_NONE;
+	}
+
       /* Get the passphrase from the user, if no key data. */
       askpass = 1;
       part = grub_partition_get_name (source->partition);


### PR DESCRIPTION
If a protector is specified, but it fails to unlock the disk, fall back to asking for the passphrase. However, an error was set indicating that the protector(s) failed. Later code (e.g., LUKS code) fails as `grub_errno` is now set. Print the existing errors out first, before proceeding with the passphrase.